### PR TITLE
[FIX] l10n_do_rnc_search: vat is no found

### DIFF
--- a/l10n_do_rnc_search/static/src/js/l10n_do_accounting.js
+++ b/l10n_do_rnc_search/static/src/js/l10n_do_accounting.js
@@ -12,7 +12,7 @@ odoo.define('l10n_do_accounting.l10n_do_accounting', function (require) {
                 source: "/dgii_ws/",
                 minLength: 3,
                 select: function (event, ui) {
-                    var $rnc = $("input[name$='vat']");
+                    var $rnc = $("div[name$='vat']").children();
                     $input.val(ui.item.name);
                     $rnc.val(ui.item.rnc).trigger("change");
 


### PR DESCRIPTION
El query para buscar el input de vat esta mal implemente, por tanto lo corregimos para odoo 15.0.